### PR TITLE
Fix use prod config

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run production

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cns-broker",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cns-broker",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "ISC",
       "dependencies": {
         "colors": "^1.4.0",


### PR DESCRIPTION
Sets entrypoint for container to run `npm run production` instead of `npm run start`